### PR TITLE
Add supply data for icRETH

### DIFF
--- a/src/providers/supply/reth.test.ts
+++ b/src/providers/supply/reth.test.ts
@@ -6,6 +6,8 @@ import { IndexREthProvider } from "./reth"
 const rpcProvider = buildAlchemyProviderPredefined(1)
 
 const AaveProtocolDataProvider = "0x7B4EB56E7CD4b454BA8ff71E4518426369a138a3"
+const SupplyCapIssuanceHook = "0xED072061e94b035B8D712c64875A469f5Dd407E6"
+const icRETH = "0xe8888Cdbc0A5958C29e7D91DAE44897c7e64F9BC"
 const rETH = "0xae78736Cd615f374D3085123A210448E74Fc6393"
 
 const AaveProtocolDataProviderAbi = [
@@ -13,8 +15,26 @@ const AaveProtocolDataProviderAbi = [
   "function getReserveCaps(address asset) external view returns (uint256 borrowCap, uint256 supplyCap)",
 ]
 
+const Erc20Abi = ["function totalSupply() public view returns (uint256)"]
+
+const SupplyCapIssuanceHookAbi = [
+  "function supplyCap() public view returns (uint256)",
+]
+
 describe("IndexREthProvider", () => {
   test("returns supply data for icRETH", async () => {
+    // icRETH
+    const icRethContract = new Contract(icRETH, Erc20Abi, rpcProvider)
+    const icRethTotalSupplyBn = await icRethContract.totalSupply()
+    const icRethTotalSupply = Number(utils.formatUnits(icRethTotalSupplyBn))
+    const supplyCapIssuanceHookContract = new Contract(
+      SupplyCapIssuanceHook,
+      SupplyCapIssuanceHookAbi,
+      rpcProvider,
+    )
+    const icRethSupplyCapBn = await supplyCapIssuanceHookContract.supplyCap()
+    const icRethSupplyCap = Number(utils.formatUnits(icRethSupplyCapBn))
+    // rETH
     const contract = new Contract(
       AaveProtocolDataProvider,
       AaveProtocolDataProviderAbi,
@@ -27,8 +47,13 @@ describe("IndexREthProvider", () => {
     const cap = Number(res.supplyCap.toString())
     const provider = new IndexREthProvider(rpcProvider)
     const supplyData = await provider.getSupplyData()
-    expect(supplyData.availableSupply).toBe(cap - totalSupply)
-    expect(supplyData.cap).toBe(cap)
-    expect(supplyData.totalSupply).toBe(totalSupply)
+    expect(supplyData.icreth.availableSupply).toBe(
+      icRethSupplyCap - icRethTotalSupply,
+    )
+    expect(supplyData.icreth.cap).toBe(icRethSupplyCap)
+    expect(supplyData.icreth.totalSupply).toBe(icRethTotalSupply)
+    expect(supplyData.reth.availableSupply).toBe(cap - totalSupply)
+    expect(supplyData.reth.cap).toBe(cap)
+    expect(supplyData.reth.totalSupply).toBe(totalSupply)
   })
 })

--- a/src/providers/supply/reth.ts
+++ b/src/providers/supply/reth.ts
@@ -1,6 +1,9 @@
 import { BigNumber, Contract, providers, utils } from "ethers"
+import { IndexSupplyProvider } from "./provider"
 
 const AaveProtocolDataProvider = "0x7B4EB56E7CD4b454BA8ff71E4518426369a138a3"
+const SupplyCapIssuanceHook = "0xED072061e94b035B8D712c64875A469f5Dd407E6"
+const icRETH = "0xe8888Cdbc0A5958C29e7D91DAE44897c7e64F9BC"
 const rETH = "0xae78736Cd615f374D3085123A210448E74Fc6393"
 
 const AaveProtocolDataProviderAbi = [
@@ -8,10 +11,20 @@ const AaveProtocolDataProviderAbi = [
   "function getReserveCaps(address asset) external view returns (uint256 borrowCap, uint256 supplyCap)",
 ]
 
+const SupplyCapIssuanceHookAbi = [
+  "function supplyCap() public view returns (uint256)",
+]
 interface IcREthSupplyData {
-  availableSupply: number
-  cap: number
-  totalSupply: number
+  icreth: {
+    availableSupply: number
+    cap: number
+    totalSupply: number
+  }
+  reth: {
+    availableSupply: number
+    cap: number
+    totalSupply: number
+  }
 }
 
 export class IndexREthProvider {
@@ -22,22 +35,41 @@ export class IndexREthProvider {
   ) {}
 
   async getSupplyData(): Promise<IcREthSupplyData> {
+    // icRETH
+    const supplyProvider = new IndexSupplyProvider(this.provider)
+    const icRethTotalSupplyBn = await supplyProvider.getSupply(icRETH)
+    const icRethTotalSupply = Number(utils.formatUnits(icRethTotalSupplyBn))
     const contract = new Contract(
       AaveProtocolDataProvider,
       AaveProtocolDataProviderAbi,
       this.provider,
     )
+    const supplyCapIssuanceHookContract = new Contract(
+      SupplyCapIssuanceHook,
+      SupplyCapIssuanceHookAbi,
+      this.provider,
+    )
+    const icRethSupplyCapBn = await supplyCapIssuanceHookContract.supplyCap()
+    const icRethSupplyCap = Number(utils.formatUnits(icRethSupplyCapBn))
+    const icRethAvailable = icRethSupplyCap - icRethTotalSupply
+    // rETH
     const aTokenTotalSupply = await contract.getATokenTotalSupply(rETH)
     const totalSupply = Math.ceil(Number(utils.formatUnits(aTokenTotalSupply)))
     const res: { borrowCap: BigNumber; supplyCap: BigNumber } =
       await contract.getReserveCaps(rETH)
     const cap = Number(res.supplyCap.toString())
-
     const availableSupply = cap - totalSupply
     return {
-      availableSupply,
-      cap,
-      totalSupply,
+      icreth: {
+        availableSupply: icRethAvailable,
+        cap: icRethSupplyCap,
+        totalSupply: icRethTotalSupply,
+      },
+      reth: {
+        availableSupply,
+        cap,
+        totalSupply,
+      },
     }
   }
 }


### PR DESCRIPTION
* Adds supply data on the _internatl_ supply cap of icRETH which is determined through the [SupplyCapIssuanceHook](https://etherscan.io/address/0xED072061e94b035B8D712c64875A469f5Dd407E6#code)