### PR TITLE
feat: Analytics options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@indexcoop/analytics-sdk",
-  "version": "0.4.0",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@indexcoop/analytics-sdk",
-      "version": "0.4.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "ethers": "^5.6.4"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build": "tsup src/index.ts --format cjs,esm --dts --clean --minify",
     "build:watch": "npm run build -- --watch src",
     "lint": "prettier -c . && eslint ./src",
+    "lint:fix": "prettier . --write && eslint ./src --fix",
     "test": "jest",
     "test:watch": "jest --watch",
     "release": "release-it"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@indexcoop/analytics-sdk",
   "description": "The AnalyticsSDK of the Index Coop.",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "engines": {
     "node": ">=18"
   },

--- a/src/providers/analytics/provider.test.ts
+++ b/src/providers/analytics/provider.test.ts
@@ -48,4 +48,31 @@ describe("IndexAnalyticsProvider", () => {
     expect(analyticsData.change24h).toEqual(change24h)
     expect(analyticsData.volume24h).toEqual(volume)
   })
+  test("returns minimum analytics data", async () => {
+    const address = "0x72e364F2ABdC788b7E918bc238B21f109Cd634D7" // MVI
+    const provider = new IndexAnalyticsProvider(rpcProvider, coingeckoService)
+    const analyticsData = await provider.getAnalytics(address, {})
+    const navPrice = await new IndexNavProvider(
+      rpcProvider,
+      coingeckoService,
+    ).getNav(address)
+    const coingeckoRes = await coingeckoService.getTokenPrice({
+      address,
+      chainId: 1,
+      baseCurrency: "usd",
+      include24hrChange: false,
+      include24hrVol: false,
+    })
+    const marketPrice = coingeckoRes[address.toLowerCase()]["usd"]
+    expect(analyticsData.address).toEqual(address)
+    expect(analyticsData.name).toEqual("Metaverse Index")
+    expect(analyticsData.symbol).toEqual("MVI")
+    expect(analyticsData.decimals).toEqual(18)
+    expect(analyticsData.marketPrice).toEqual(marketPrice)
+    expect(analyticsData.navPrice).toEqual(navPrice)
+    expect(analyticsData.marketCap).toEqual(null)
+    expect(analyticsData.totalSupply).toEqual(null)
+    expect(analyticsData.change24h).toEqual(null)
+    expect(analyticsData.volume24h).toEqual(null)
+  })
 })

--- a/src/providers/analytics/provider.ts
+++ b/src/providers/analytics/provider.ts
@@ -1,6 +1,11 @@
 import { providers, utils } from "ethers"
 
-import { CoinGeckoService, CoinGeckoUtils, CoingeckoTokenPriceResponse, getFulfilledValueOrNull } from "../../utils"
+import {
+  CoinGeckoService,
+  CoinGeckoUtils,
+  CoingeckoTokenPriceResponse,
+  getFulfilledValueOrNull,
+} from "../../utils"
 import { IndexMarketCapProvider } from "../marketcap"
 import { IndexNavProvider } from "../nav"
 import { IndexSupplyProvider } from "../supply"
@@ -86,7 +91,11 @@ export class IndexAnalyticsProvider implements AnalyticsProvider {
         coingeckoPromise,
       ])
     const totalSupplyValue = getFulfilledValueOrNull(totalSupply)
-    const coingeckoData = (getFulfilledValueOrNull(coingeckoRes) as CoingeckoTokenPriceResponse | null)?.[address.toLowerCase()]
+    const coingeckoData = (
+      getFulfilledValueOrNull(
+        coingeckoRes,
+      ) as CoingeckoTokenPriceResponse | null
+    )?.[address.toLowerCase()]
     const token = TokenData[address.toLowerCase()]
 
     const change24hLabel = CoinGeckoUtils.get24hChangeLabel(baseCurrency)
@@ -97,10 +106,9 @@ export class IndexAnalyticsProvider implements AnalyticsProvider {
       address,
       name: token.name,
       decimals: token.decimals,
-      totalSupply:
-        totalSupplyValue
-          ? utils.formatUnits(totalSupplyValue.toString())
-          : null,
+      totalSupply: totalSupplyValue
+        ? utils.formatUnits(totalSupplyValue.toString())
+        : null,
       marketPrice: coingeckoData?.[baseCurrency] ?? null,
       navPrice: getFulfilledValueOrNull(navPrice) as number | null,
       marketCap: getFulfilledValueOrNull(marketCap) as number | null,

--- a/src/providers/analytics/provider.ts
+++ b/src/providers/analytics/provider.ts
@@ -1,6 +1,6 @@
 import { providers, utils } from "ethers"
 
-import { CoinGeckoService, CoinGeckoUtils } from "../../utils"
+import { CoinGeckoService, CoinGeckoUtils, CoingeckoTokenPriceResponse, getFulfilledValueOrNull } from "../../utils"
 import { IndexMarketCapProvider } from "../marketcap"
 import { IndexNavProvider } from "../nav"
 import { IndexSupplyProvider } from "../supply"
@@ -85,12 +85,8 @@ export class IndexAnalyticsProvider implements AnalyticsProvider {
         navPricePromise,
         coingeckoPromise,
       ])
-    const totalSupplyValue =
-      totalSupply.status === "fulfilled" ? totalSupply.value : null
-    const coingeckoData =
-      coingeckoRes.status === "fulfilled"
-        ? coingeckoRes.value?.[address.toLowerCase()]
-        : null
+    const totalSupplyValue = getFulfilledValueOrNull(totalSupply)
+    const coingeckoData = (getFulfilledValueOrNull(coingeckoRes) as CoingeckoTokenPriceResponse | null)?.[address.toLowerCase()]
     const token = TokenData[address.toLowerCase()]
 
     const change24hLabel = CoinGeckoUtils.get24hChangeLabel(baseCurrency)
@@ -106,8 +102,8 @@ export class IndexAnalyticsProvider implements AnalyticsProvider {
           ? utils.formatUnits(totalSupplyValue.toString())
           : null,
       marketPrice: coingeckoData?.[baseCurrency] ?? null,
-      navPrice: navPrice.status === "fulfilled" ? navPrice.value : null,
-      marketCap: marketCap.status === "fulfilled" ? marketCap.value : null,
+      navPrice: getFulfilledValueOrNull(navPrice) as number | null,
+      marketCap: getFulfilledValueOrNull(marketCap) as number | null,
       change24h: coingeckoData?.[change24hLabel] ?? null,
       volume24h: coingeckoData?.[volume24hLabel] ?? null,
     }

--- a/src/providers/analytics/provider.ts
+++ b/src/providers/analytics/provider.ts
@@ -60,7 +60,7 @@ export class IndexAnalyticsProvider implements AnalyticsProvider {
 
     const supplyPromise = options.includeTotalSupply
       ? new IndexSupplyProvider(provider).getSupply(address)
-      : Promise.resolve(null)
+      : null
     const marketCapPromise = marketCapProvider.getMarketCap(address)
     const navPricePromise = navProvider.getNav(address)
     const coingeckoPromise = coingeckoService.getTokenPrice({
@@ -78,6 +78,7 @@ export class IndexAnalyticsProvider implements AnalyticsProvider {
         navPricePromise,
         coingeckoPromise,
       ])
+      const totalSupplyValue = totalSupply.status === 'fulfilled' ? totalSupply.value : null
     const coingeckoData =
       coingeckoRes.status === "fulfilled"
         ? coingeckoRes.value?.[address.toLowerCase()]
@@ -90,8 +91,8 @@ export class IndexAnalyticsProvider implements AnalyticsProvider {
       name: token.name,
       decimals: token.decimals,
       totalSupply:
-        options.includeTotalSupply && totalSupply
-          ? utils.formatUnits(totalSupply.toString())
+        options.includeTotalSupply && totalSupplyValue
+          ? utils.formatUnits(totalSupplyValue.toString())
           : null,
       marketPrice: coingeckoData?.[baseCurrency] ?? null,
       navPrice: navPrice.status === "fulfilled" ? navPrice.value : null,

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -3,6 +3,8 @@ import { CoingeckoTokenPriceResponse } from "./coingecko"
 
 type SettledResponse = BigNumber | CoingeckoTokenPriceResponse | number | null
 
-export function getFulfilledValueOrNull(res: PromiseSettledResult<SettledResponse>): SettledResponse {
-  return res.status === 'fulfilled' ? res.value : null
+export function getFulfilledValueOrNull(
+  res: PromiseSettledResult<SettledResponse>,
+): SettledResponse {
+  return res.status === "fulfilled" ? res.value : null
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,0 +1,8 @@
+import { BigNumber } from "ethers"
+import { CoingeckoTokenPriceResponse } from "./coingecko"
+
+type SettledResponse = BigNumber | CoingeckoTokenPriceResponse | number | null
+
+export function getFulfilledValueOrNull(res: PromiseSettledResult<SettledResponse>): SettledResponse {
+  return res.status === 'fulfilled' ? res.value : null
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./coingecko"
+export * from "./helpers"
 export * from "./positions"
 export * from "./providers"


### PR DESCRIPTION
Adds support for an `options` object to avoid fetching certain data. Also runs all requests in parallel.