### PR TITLE
chore: Add rejection reason log

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@indexcoop/analytics-sdk",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@indexcoop/analytics-sdk",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "ethers": "^5.6.4"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@indexcoop/analytics-sdk",
   "description": "The AnalyticsSDK of the Index Coop.",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "engines": {
     "node": ">=18"
   },

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -3,8 +3,14 @@ import { CoingeckoTokenPriceResponse } from "./coingecko"
 
 type SettledResponse = BigNumber | CoingeckoTokenPriceResponse | number | null
 
+// Returns the fulfilled value in case of success and otherwise
+// logs the reason for rejection
 export function getFulfilledValueOrNull(
   res: PromiseSettledResult<SettledResponse>,
 ): SettledResponse {
+  if (res.status === "rejected") {
+    console.error(res.reason)
+  }
+
   return res.status === "fulfilled" ? res.value : null
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -4,7 +4,7 @@ import { CoingeckoTokenPriceResponse } from "./coingecko"
 type SettledResponse = BigNumber | CoingeckoTokenPriceResponse | number | null
 
 // Returns the fulfilled value in case of success and otherwise
-// logs the reason for rejection
+// returns null and logs the reason for rejection
 export function getFulfilledValueOrNull(
   res: PromiseSettledResult<SettledResponse>,
 ): SettledResponse {


### PR DESCRIPTION
Logs the reason for a `rejected` request, which is now squelched by `allSettled`