### PR TITLE
fix: JsonRpcProvider setup

### DIFF
--- a/src/providers/analytics/provider.ts
+++ b/src/providers/analytics/provider.ts
@@ -63,7 +63,7 @@ export class IndexAnalyticsProvider implements AnalyticsProvider {
       throw new Error("Unknown index token or wrong chainId")
     }
 
-    const provider = getRpcProvider(this.rpcUrl)
+    const provider = getRpcProvider(this.rpcUrl, true)
     const { baseCurrency, coingeckoService } = this
     const supplyProvider = new IndexSupplyProvider(provider)
     const marketCapProvider = new IndexMarketCapProvider(

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -35,5 +35,5 @@ export function buildAlchemyProviderUrl(
 }
 
 export function getRpcProvider(rpcUrl: string) {
-  return new providers.JsonRpcProvider(rpcUrl)
+  return new providers.JsonRpcProvider({ url: rpcUrl, skipFetchSetup: true })
 }

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -20,9 +20,10 @@ export function getAlchemySubdomain(chainId: number): string | null {
 export function buildAlchemyProvider(
   chainId: number,
   apiKey: string,
+  skipFetchSetup?: boolean,
 ): providers.JsonRpcProvider {
   const url = buildAlchemyProviderUrl(chainId, apiKey)
-  return new providers.JsonRpcProvider(url)
+  return new providers.JsonRpcProvider({ url, skipFetchSetup })
 }
 
 export function buildAlchemyProviderUrl(
@@ -34,6 +35,6 @@ export function buildAlchemyProviderUrl(
   return url
 }
 
-export function getRpcProvider(rpcUrl: string) {
-  return new providers.JsonRpcProvider({ url: rpcUrl, skipFetchSetup: true })
+export function getRpcProvider(rpcUrl: string, skipFetchSetup?: boolean) {
+  return new providers.JsonRpcProvider({ url: rpcUrl, skipFetchSetup })
 }


### PR DESCRIPTION
Need to set `skipFetchSetup` per https://docs.ethers.org/v5/single-page/ since we're running on workers.