### PR TITLE
feat: add base currency config for coingecko token stats

### DIFF
--- a/src/providers/coingecko/provider.test.ts
+++ b/src/providers/coingecko/provider.test.ts
@@ -24,4 +24,15 @@ describe("CoingeckoProvider", () => {
     expect(data.low24h).toBeGreaterThan(0)
     expect(data.high24h).toBeGreaterThan(0)
   })
+
+  test("returns token data for BTC/ETH ratio", async () => {
+    const provider = new CoingeckoProvider(coingeckoService)
+    const data = await provider.getTokenStats("BTC", "eth")
+    console.log(data)
+    expect(data.symbol).toBe("BTC")
+    expect(data.price).toBeGreaterThan(0)
+    expect(typeof data.change24h).toBe("number")
+    expect(data.low24h).toBeGreaterThan(0)
+    expect(data.high24h).toBeGreaterThan(0)
+  })
 })

--- a/src/providers/coingecko/provider.ts
+++ b/src/providers/coingecko/provider.ts
@@ -22,7 +22,7 @@ export class CoingeckoProvider {
 
   async getTokenStats(
     symbol: string,
-    baseCurrency: string = "usd",
+    baseCurrency = "usd",
   ): Promise<TokenStatsResponse> {
     const { coingeckoService } = this
     const coinId = getCoingeckoId(symbol)

--- a/src/providers/coingecko/provider.ts
+++ b/src/providers/coingecko/provider.ts
@@ -20,9 +20,11 @@ function getCoingeckoId(symbol: string) {
 export class CoingeckoProvider {
   constructor(private readonly coingeckoService: CoinGeckoService) {}
 
-  async getTokenStats(symbol: string): Promise<TokenStatsResponse> {
+  async getTokenStats(
+    symbol: string,
+    baseCurrency: string = "usd",
+  ): Promise<TokenStatsResponse> {
     const { coingeckoService } = this
-    const baseCurrency = "usd"
     const coinId = getCoingeckoId(symbol)
     const simplePriceData = (
       await coingeckoService.getTokenPriceById({


### PR DESCRIPTION
Adds option to config the base currency for token stats to be able to define other currencies than USD.